### PR TITLE
feat: handle missing coretemp data

### DIFF
--- a/tests/test_hw_stats.py
+++ b/tests/test_hw_stats.py
@@ -127,3 +127,15 @@ def test_try_get_gpu_handle(mock_register):
         with patch("transport.hw_stats.pynvml.nvmlInit", side_effect=mock_pynvml.NVMLError_LibraryNotFound):
             result = hw_stats.try_get_gpu_handle()
             assert result is None
+
+def test_cpu_temps_not_available(monkeypatch):
+    """If psutil.sensors_temperatures() does not have 'coretemp' available,
+    _get_cpu_temps should return a list with a single CoreTemp value with label 'N/A'.
+    """
+    monkeypatch.setattr("transport.hw_stats.psutil.sensors_temperatures", 
+                        MagicMock(return_value={}))
+
+    result = hw_stats._get_cpu_temps()
+    assert len(result) == 1
+    assert result[0].label == "N/A"
+    assert result[0].value == 0

--- a/transport/hw_stats.py
+++ b/transport/hw_stats.py
@@ -150,7 +150,12 @@ def _get_cpu_temps() -> list[namedtuple]:
                     and sensor.Name.startswith(("CPU Core #", "CPU Package"))
                     and "Distance to TjMax" not in sensor.Name]
     else:
-        temps = psutil.sensors_temperatures()["coretemp"]
+        temps = psutil.sensors_temperatures().get("coretemp", [])
+
+        # coretemp is not available on all systems
+        if not temps:
+            return [CoreTemp("N/A", 0)]
+
         values = [CoreTemp(t.label, t.current) for t in temps]
     
     # Sort by core label to ensure consistent order.


### PR DESCRIPTION
Return an empty value as CPU temperature if `psutil` cannot detect `coretemp` data